### PR TITLE
Speed up webpack build in development environment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4847,6 +4847,91 @@
         "har-schema": "^2.0.0"
       }
     },
+    "hard-source-webpack-plugin": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/hard-source-webpack-plugin/-/hard-source-webpack-plugin-0.13.1.tgz",
+      "integrity": "sha512-r9zf5Wq7IqJHdVAQsZ4OP+dcUSvoHqDMxJlIzaE2J0TZWn3UjMMrHqwDHR8Jr/pzPfG7XxSe36E7Y8QGNdtuAw==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.1",
+        "find-cache-dir": "^2.0.0",
+        "graceful-fs": "^4.1.11",
+        "lodash": "^4.15.0",
+        "mkdirp": "^0.5.1",
+        "node-object-hash": "^1.2.0",
+        "parse-json": "^4.0.0",
+        "pkg-dir": "^3.0.0",
+        "rimraf": "^2.6.2",
+        "semver": "^5.6.0",
+        "tapable": "^1.0.0-beta.5",
+        "webpack-sources": "^1.0.1",
+        "write-json-file": "^2.3.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.1.0.tgz",
+          "integrity": "sha512-NhURkNcrVB+8hNfLuysU8enY5xn2KXphsHBaC2YmRNTZRc7RWusw6apSpdEj3jo4CMb6W9nrF6tTnsJsJeyu6g==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
+          "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==",
+          "dev": true
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
+          }
+        },
+        "pkg-dir": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+          "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+          "dev": true,
+          "requires": {
+            "find-up": "^3.0.0"
+          }
+        }
+      }
+    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -7268,6 +7353,12 @@
         "shellwords": "^0.1.1",
         "which": "^1.3.0"
       }
+    },
+    "node-object-hash": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/node-object-hash/-/node-object-hash-1.4.2.tgz",
+      "integrity": "sha512-UdS4swXs85fCGWWf6t6DMGgpN/vnlKeSGEQ7hJcrs7PBFoxoKLmibc3QRb7fwiYsjdL7PX8iI/TMSlZ90dgHhQ==",
+      "dev": true
     },
     "normalize-package-data": {
       "version": "2.4.0",
@@ -10336,6 +10427,28 @@
         "graceful-fs": "^4.1.11",
         "imurmurhash": "^0.1.4",
         "signal-exit": "^3.0.2"
+      }
+    },
+    "write-json-file": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/write-json-file/-/write-json-file-2.3.0.tgz",
+      "integrity": "sha1-K2TIozAE1UuGmMdtWFp3zrYdoy8=",
+      "dev": true,
+      "requires": {
+        "detect-indent": "^5.0.0",
+        "graceful-fs": "^4.1.2",
+        "make-dir": "^1.0.0",
+        "pify": "^3.0.0",
+        "sort-keys": "^2.0.0",
+        "write-file-atomic": "^2.0.0"
+      },
+      "dependencies": {
+        "detect-indent": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
+          "integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
+          "dev": true
+        }
       }
     },
     "ws": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10185,6 +10185,15 @@
         }
       }
     },
+    "webpack-merge": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-4.2.1.tgz",
+      "integrity": "sha512-4p8WQyS98bUJcCvFMbdGZyZmsKuWjWVnVHnAS3FFg0HDaRVrPbkivx2RYCre8UiemD67RsiFFLfn4JhLAin8Vw==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.5"
+      }
+    },
     "webpack-sources": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@types/moment": "^2.13.0",
     "@types/moment-timezone": "^0.5.10",
     "@types/node": "^10.12.19",
+    "hard-source-webpack-plugin": "^0.13.1",
     "jest": "^23.6.0",
     "prettier": "^1.16.2",
     "prettier-tslint": "^0.4.2",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "build": "webpack --config webpack.prod.js",
+    "build:dev": "webpack --config webpack.dev.js",
     "test": "jest"
   },
   "author": "",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "build": "webpack --mode production",
+    "build": "webpack --config webpack.prod.js",
     "test": "jest"
   },
   "author": "",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "tslint-plugin-prettier": "^2.0.1",
     "typescript": "^3.2.4",
     "webpack": "^4.29.0",
-    "webpack-cli": "^3.2.1"
+    "webpack-cli": "^3.2.1",
+    "webpack-merge": "^4.2.1"
   },
   "dependencies": {
     "@google-cloud/datastore": "^3.0.1",

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -3,7 +3,6 @@ const path = require('path');
 module.exports = {
   entry: "./src/index.ts",
   target: 'node',
-  devtool: 'source-map',
   output: {
     path: __dirname,
     filename: 'index.js',

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -1,0 +1,6 @@
+const merge = require('webpack-merge');
+const common = require('./webpack.common.js');
+
+module.exports = merge(common, {
+  mode: 'development'
+});

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -1,6 +1,8 @@
 const merge = require('webpack-merge');
 const common = require('./webpack.common.js');
+const HardSourceWebpackPlugin = require('hard-source-webpack-plugin');
 
 module.exports = merge(common, {
-  mode: 'development'
+  mode: 'development',
+  plugins: [ new HardSourceWebpackPlugin() ]
 });

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -1,0 +1,7 @@
+const merge = require('webpack-merge');
+const common = require('./webpack.common.js');
+
+module.exports = merge(common, {
+  mode: 'production',
+  devtool: 'source-map',
+});


### PR DESCRIPTION
## 目的

localでの webpackのbuild時間を高速にしたい

https://webpack.js.org/guides/production/#simple-approach

- この資料を読むと、production環境は軽量にするべきと書かれている。
- しかしながら cloud functionsの用途であれば、production環境こそ devtoolを `source-map` として、エラーの内容の詳細を stack driverに送信したい
- そして簡単に動作確認をするために development環境のbuildは軽量にしたい

## 方法

- webpackのbuild方法について、時間が掛かってもsourcemapを残したいproduction buildと、時間を掛けずにサクサク buildしたい development buildの2つに分けた。
- localにbuildのcacheを作るwebpackのpluginを導入した。
  - https://github.com/mzgoddard/hard-source-webpack-plugin

### 参考資料
- webpackのplugin
  - https://github.com/mzgoddard/hard-source-webpack-plugin
- build optionを環境毎に変更する方法 
  - https://webpack.js.org/guides/production/#simple-approach
- devtoolの説明
  - https://webpack.js.org/configuration/devtool/

## 結果
### dev

```
$ time npm run build:dev
npm run build:dev  1.33s user 0.22s system 96% cpu 1.614 total
```

### prod (`"devtool" : "source-map"` の場合)

```
$ time npm run build
npm run build  5.60s user 0.44s system 133% cpu 4.529 total
```

### 備考 (`"devtool" : "none"` の場合)

```
$ time npm run build:dev
npm run build:dev  4.14s user 0.34s system 133% cpu 3.350 total
```

## その他

5秒くらいのbuild時間なら、`webpack-dev-server` で変更検知したらbuildくらいでも良いかもなぁ
